### PR TITLE
Rename documentation files so GitHub renders them

### DIFF
--- a/doc/design/1a-Homework.markdown
+++ b/doc/design/1a-Homework.markdown
@@ -1,4 +1,5 @@
 Re-engineering (1): Homework
+============================
 
 BACKGROUND
 ==========

--- a/doc/design/1b-AllAboutJNI.markdown
+++ b/doc/design/1b-AllAboutJNI.markdown
@@ -1,4 +1,5 @@
 Re-engineering (1): The Java Native Interface 
+=============================================
 
 There's one other vitally important area of background information necessary
 to grok; I should have included this in the Homework email. It's hard to

--- a/doc/design/2a-ObjectiveAndAudience.markdown
+++ b/doc/design/2a-ObjectiveAndAudience.markdown
@@ -1,6 +1,7 @@
 Re-engineering (2): Objective and Audience
+==========================================
 
-Now that you've done your homework, we can talk about where we're going and
+Now that you've done some homework, we can talk about where we're going and
 why.
 
 As I've said elsewhere on many occasions, I have the utmost respect for the

--- a/doc/design/2b-DesignConstraints.markdown
+++ b/doc/design/2b-DesignConstraints.markdown
@@ -1,4 +1,5 @@
 Re-engineering (2): Design constraints
+======================================
 
 The issue of audience described in my last message has a significant impact on
 our design. You've probably already guessed:

--- a/doc/design/3a-PackageNames.markdown
+++ b/doc/design/3a-PackageNames.markdown
@@ -1,4 +1,5 @@
 Re-engineering (3): Package names
+=================================
 
 This is a minor matter, but while we're breaking everything anyway, several
 people have commented that the old java-gnome 2.x package names were _really_

--- a/doc/design/3b-VersionNumbers.markdown
+++ b/doc/design/3b-VersionNumbers.markdown
@@ -1,4 +1,5 @@
 Re-engineering (3): Version numbers
+===================================
 
 I've stated my [views about
 versioning](http://sourceforge.net/mailarchive/message.php?msg_id=3D15113906)

--- a/doc/design/4a-TreeViewAndTreeModel.markdown
+++ b/doc/design/4a-TreeViewAndTreeModel.markdown
@@ -1,4 +1,5 @@
 Re-engineering (4): TreeView and TreeModel API design
+=====================================================
 
 A few weeks ago I wrote:
 

--- a/doc/design/4b-ObjectProperties.markdown
+++ b/doc/design/4b-ObjectProperties.markdown
@@ -1,4 +1,5 @@
 Re-engineering (4): GObject property handling API
+=================================================
 
 I was chatting with Davyd last night about how I'd achieved a generalized
 setProperty() capability for GObjects in the new bindings. I wrote him an

--- a/doc/design/5a-Architecture.markdown
+++ b/doc/design/5a-Architecture.markdown
@@ -1,4 +1,5 @@
 Re-engineering (5): Internal Architecture
+=========================================
 
 I have alluded several times to having worked out an architecture that I think
 will do nicely for us given the constraints that I have articulated.

--- a/doc/design/START.markdown
+++ b/doc/design/START.markdown
@@ -32,28 +32,28 @@ The design documents are loosely organized according to the following scheme:
 
 1. Background material:
 
-	* [The Great Owen Thread and other necessary homework](1a-Homework.html)
-	* [Java Native Interface](1b-AllAboutJNI.html)
+	* [The Great Owen Thread and other necessary homework](1a-Homework.markdown)
+	* [Java Native Interface](1b-AllAboutJNI.markdown)
 
 2. Governing assumptions (our objective as a project, who our audience is, and
    what constraints we impose on ourselves as we go about our business):
 
-   	* [Objective and Audience](2a-ObjectiveAndAudience.html)
-	* [Design Constraints](2b-DesignConstraints.html)
+   	* [Objective and Audience](2a-ObjectiveAndAudience.markdown)
+	* [Design Constraints](2b-DesignConstraints.markdown)
 
 3. Miscellaneous organizational decisions:
 
-	* [Package Names](3a-PackageNames.html)
-	* [Version Numbering](3b-VersionNumbers.html)
+	* [Package Names](3a-PackageNames.markdown)
+	* [Version Numbering](3b-VersionNumbers.markdown)
 
 4. Discussion of public APIs:
 
-	* [TreeView, TreeModel](4a-TreeViewAndTreeModel.html)
-	* [GObject properties](4b-ObjectProperties.html)
+	* [TreeView, TreeModel](4a-TreeViewAndTreeModel.markdown)
+	* [GObject properties](4b-ObjectProperties.markdown)
 
 5. Architecture:
 
-	* [Internal Architecture](5a-Architecture.html)
+	* [Internal Architecture](5a-Architecture.markdown)
 
 These numbers correspond to those used to organize the original threads on the
 java-gnome-hackers mailing list. All of these documents started life as emails
@@ -67,13 +67,13 @@ About the format of our documentation
 
 These documents are all text files! They are, however, _**lightly**_ marked up
 with the syntax of John Gruber's "[Markdown][markdown]" so that they also
-present nicely as web pages. See [`doc/style/MARKUP`](../style/MARKUP.html)
+present nicely as web pages. See [`doc/style/MARKUP`](../style/MARKUP.markdown)
 for details.
 
 As conventions, we:
 
 * put the title of the document by itself on the first line of the file (the
-  script that renders these to HTML on our website picks this up as `<TITLE>`
+  script that renders these to markdown on our website picks this up as `<TITLE>`
   and top banner `<H1>` heading for the document),
 
 * note, _in italics_, the date of the last significant modification at the

--- a/doc/examples/START.markdown
+++ b/doc/examples/START.markdown
@@ -1,4 +1,5 @@
 EXAMPLES
+========
 
 These files are examples of specific parts of the java-gnome API worked up as
 complete Java programs.

--- a/doc/style/CodeFormat.markdown
+++ b/doc/style/CodeFormat.markdown
@@ -1,4 +1,5 @@
 Style guide: Source Code
+========================
 
 Code Formatting
 ===============

--- a/doc/style/CommitMessages.markdown
+++ b/doc/style/CommitMessages.markdown
@@ -1,4 +1,5 @@
 Style guide: Commit Messages
+============================
 
 It might seem a bit anal to ask people to follow certain conventions when
 writing their commit messages, but reading code history is a big part of

--- a/doc/style/Documentation.markdown
+++ b/doc/style/Documentation.markdown
@@ -1,4 +1,5 @@
 Style guide: Documentation
+==========================
 
 Text files
 ==========

--- a/doc/style/MARKUP.markdown
+++ b/doc/style/MARKUP.markdown
@@ -1,4 +1,5 @@
 MARKUP
+======
 
 About the format of these documents
 -----------------------------------


### PR DESCRIPTION
Rename the files in _doc/_ to have a _.markdown_ extension so GitHub renders them in a web browser.